### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -23,8 +23,8 @@ qpsk125Tx	KEYWORD2
 rttyTx	KEYWORD2
 hellTx	KEYWORD2
 wsprTx	KEYWORD2
-wsprProcess KEYWORD2
-ddsPower  KEYWORD2
+wsprProcess	KEYWORD2
+ddsPower	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords